### PR TITLE
Implement special backoff behavior on HTTP 409

### DIFF
--- a/cloud_profiler_agent.gemspec
+++ b/cloud_profiler_agent.gemspec
@@ -16,6 +16,7 @@ Gem::Specification.new do |spec|
   spec.files         = ['lib/profile_pb.rb',
                         'lib/cloud_profiler_agent.rb',
                         'lib/cloud_profiler_agent/agent.rb',
+                        'lib/cloud_profiler_agent/looper.rb',
                         'lib/cloud_profiler_agent/pprof_builder.rb']
 
   spec.add_runtime_dependency 'google-api-client', '~> 0.49'

--- a/lib/cloud_profiler_agent.rb
+++ b/lib/cloud_profiler_agent.rb
@@ -4,6 +4,7 @@ module CloudProfilerAgent
   VERSION = '0.0.1.pre'
   autoload :Agent, 'cloud_profiler_agent/agent'
   autoload :PprofBuilder, 'cloud_profiler_agent/pprof_builder'
+  autoload :Looper, 'cloud_profiler_agent/looper'
 end
 
 module Perftools

--- a/lib/cloud_profiler_agent/agent.rb
+++ b/lib/cloud_profiler_agent/agent.rb
@@ -102,7 +102,8 @@ module CloudProfilerAgent
 
     def profile(duration, mode)
       start_time = Time.now
-      stackprof = StackProf.run(mode: mode, raw: true) do
+      # interval is in microseconds for :cpu and :wall, number of allocations for :object
+      stackprof = StackProf.run(mode: mode, raw: true, interval: 1000) do
         sleep(duration)
       end
 

--- a/lib/cloud_profiler_agent/looper.rb
+++ b/lib/cloud_profiler_agent/looper.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+require 'google/apis/errors'
+
+module CloudProfilerAgent
+  # Looper is responsible for the main loop of the agent. It calls a
+  # block repeatedly, handling errors, backing off, and retrying as
+  # appropriate.
+  class Looper
+    def initialize(
+      min_iteration_sec: 10,
+      max_iteration_sec: 60 * 60,
+      backoff_factor: 1.5,
+      debug_logging: false,
+      sleeper: ->(sec) { sleep(sec) },
+      clock: -> { Process.clock_gettime(Process::CLOCK_MONOTONIC) },
+      rander: -> { rand }
+    )
+
+      # the minimum and maximum time between iterations of the profiler loop,
+      # in seconds. Normally the Cloud Profiler API tells us how fast to go,
+      # but we back off in case of error.
+      @min_iteration_sec = min_iteration_sec
+      @max_iteration_sec = max_iteration_sec
+      @backoff_factor = backoff_factor
+
+      # stubbable for testing
+      @sleeper = sleeper
+      @clock = clock
+      @rander = rander
+
+      @debug_logging = debug_logging
+    end
+
+    attr_reader :min_iteration_sec, :max_iteration_sec, :backoff_factor
+
+    def run(max_iterations = 0)
+      iterations = 0
+      iteration_time = @min_iteration_sec
+      loop do
+        start_time = @clock.call
+        iterations += 1
+        begin
+          yield
+        rescue ::Google::Apis::ClientError => e
+          backoff = backoff_duration(e)
+          if backoff.nil?
+            iteration_time = @max_iteration_sec
+          else
+            debug_log("sleeping for #{backoff} at request of server")
+            # This might be longer than max_iteration_sec and that's OK: with
+            # a very large number of agents it might be necessary to achieve
+            # the objective of 1 profile per minute.
+            @sleeper.call(backoff)
+            iteration_time = @min_iteration_sec
+          end
+        rescue StandardError => e
+          iteration_time *= @backoff_factor + @rander.call / 2
+          elapsed = @clock.call - start_time
+          debug_log("Cloud Profiler agent encountered error after #{elapsed} seconds, will retry: #{e.inspect}")
+        else
+          iteration_time = @min_iteration_sec
+        end
+
+        return unless iterations < max_iterations || max_iterations.zero?
+
+        iteration_time = [@max_iteration_sec, iteration_time].min
+        next_time = start_time + iteration_time
+        delay = next_time - @clock.call
+        @sleeper.call(delay) if delay.positive?
+      end
+    end
+
+    private
+
+    def backoff_duration(error)
+      # It's unclear how this should work, so this is based on a guess.
+      #
+      # https://github.com/googleapis/google-api-ruby-client/issues/1498
+      match = /backoff for (?:(\d+)h)?(?:(\d+)m)?(?:(\d+)s)?/.match(error.message)
+      return nil if match.nil?
+
+      hours = Integer(match[1] || 0)
+      minutes = Integer(match[2] || 0)
+      seconds = Integer(match[3] || 0)
+
+      seconds + minutes * 60 + hours * 60 * 60
+    end
+
+    def debug_log(message)
+      puts(message) if @debug_logging
+    end
+  end
+end

--- a/spec/looper_spec.rb
+++ b/spec/looper_spec.rb
@@ -1,0 +1,157 @@
+# frozen_string_literal: true
+
+require 'cloud_profiler_agent'
+
+RSpec.describe CloudProfilerAgent::Looper do
+  before do
+    @now = 0.0
+    @sleeps = []
+    @rand = 0.4 # chosen by fair dice roll. guaranteed to be random.
+  end
+
+  subject do
+    described_class.new(
+      clock: -> { @now },
+      sleeper: ->(secs) { @sleeps.push(secs); @now += secs },
+      rander: -> { @rand }
+    )
+  end
+
+  let(:min_time) { subject.min_iteration_sec }
+  let(:max_time) { subject.max_iteration_sec }
+  let(:backoff) { subject.backoff_factor }
+
+  describe '#run' do
+    it 'runs the block the specified number of times' do
+      runs = []
+      subject.run(3) do
+        runs.push(true)
+      end
+      expect(runs.length).to eq(3)
+    end
+
+    it 'runs the block forever when max_iterations is not given' do
+      # but we don't test this, because how do you test an infinite loop?
+    end
+
+    it 'will not run faster than min_iteration_sec' do
+      subject.run(3) {}
+      expect(@sleeps).to eq([min_time, min_time])
+    end
+
+    context 'when the block takes some time' do
+      it 'accounts for time taken by the block' do
+        subject.run(3) { @now += 1 }
+        expect(@sleeps).to eq([min_time - 1, min_time - 1])
+      end
+    end
+
+    context 'when the block takes longer than min_iteration_sec' do
+      it 'does not sleep between iterations' do
+        subject.run(3) { @now += 11 }
+        expect(@sleeps).to eq([])
+      end
+    end
+
+    context 'when the block raises a StandardError' do
+      it 'exponentially backs off' do
+        subject.run(3) do
+          @now += 1
+          raise StandardError, 'bam'
+        end
+
+        factor = backoff + @rand / 2
+        expect(@sleeps).to eq([min_time * factor - 1, min_time * factor**2 - 1])
+      end
+
+      it 'respects max_iteration_sec' do
+        subject.run(15) do
+          @now += 1
+          raise StandardError, 'bam'
+        end
+
+        expect(@sleeps.last).to eq(max_time - 1)
+      end
+    end
+
+    context 'when the block raises an Exception' do
+      it 'does not rescue' do
+        expect { subject.run(15) { raise Exception, 'bam' } }.to raise_error(Exception, 'bam')
+      end
+    end
+
+    context 'when Google asks for backoff' do
+      it 'slows down' do
+        subject.run(2) do
+          @now += 1
+          raise backoff_exception('44m0s')
+        end
+
+        expect(@sleeps.first).to eq(60 * 44)
+      end
+    end
+
+    context 'when the block raises some other ClientError' do
+      it 'goes to the maximum iteration time' do
+        subject.run(2) do
+          @now += 1
+          raise ::Google::Apis::ClientError.new('you are a bad client', status_code: 400)
+        end
+
+        expect(@sleeps).to eq([max_time - 1])
+      end
+    end
+
+    context 'when the block fails then works' do
+      it 'backs off then returns to normal' do
+        i = 0
+        subject.run(4) do
+          @now += 1
+          i += 1
+          raise 'whoops' if i == 1
+        end
+
+        factor = backoff + @rand / 2
+        expect(@sleeps).to eq([min_time * factor - 1, min_time - 1, min_time - 1])
+      end
+    end
+  end
+
+  describe '#max_iteration_sec' do
+    it 'is 1 hour by default' do
+      expect(subject.max_iteration_sec).to eq(60 * 60)
+    end
+  end
+
+  describe '#min_iteration_sec' do
+    it 'is 10 seconds by default' do
+      expect(subject.min_iteration_sec).to eq(10)
+    end
+  end
+
+  describe '#backoff_factor' do
+    it 'is 1.5 by default' do
+      expect(subject.backoff_factor).to eq(1.5)
+    end
+  end
+
+  def backoff_exception(duration)
+    message = "action throttled, backoff for #{duration}"
+    body = "{
+      \"error\": {
+        \"code\": 409,
+        \"message\": \"generic::aborted: action throttled, backoff for #{duration}\",
+        \"errors\": [
+          {
+            \"message\": \"generic::aborted: action throttled, backoff for #{duration}\",
+            \"domain\": \"global\",
+            \"reason\": \"aborted\"
+          }
+        ],
+        \"status\": \"ABORTED\"
+      }
+    }
+    "
+    ::Google::Apis::ClientError.new(message, status_code: 409, body: body)
+  end
+end


### PR DESCRIPTION
It's clear from the documentation that Google may respond with a message
asking the client to back off, but it's not clear what form that takes
over the HTTP API. It seems though it could be an HTTP 409, so make an
effort to parse and respect that.

Since the looping and retry logic was getting complicated enough, it's
been extracted to a separate Looper class. Besides the new behavior on
HTTP 4xx responses, it should be unchanged.